### PR TITLE
Use ActiveRecord v5 data_source_exists? if in use

### DIFF
--- a/lib/rspec_profiling/collectors/psql.rb
+++ b/lib/rspec_profiling/collectors/psql.rb
@@ -63,7 +63,15 @@ module RspecProfiling
       private
 
       def prepared?
-        connection.table_exists?(table)
+        if active_record5_or_up?
+          connection.data_source_exists?(table)
+        else
+          connection.table_exists?(table)
+        end
+      end
+
+      def active_record5_or_up?
+        ActiveRecord::VERSION::STRING[0].to_i >= 5
       end
 
       def connection


### PR DESCRIPTION
ActiveRecord v5 deprecated the use of `table_exists?` in favor of `data_source_exists`. This commit dynamically checks whether v5+ is in use, and falls back to the legacy method otherwise.